### PR TITLE
Add solib version number to CMakeLists.txt

### DIFF
--- a/DevIL/src-IL/CMakeLists.txt
+++ b/DevIL/src-IL/CMakeLists.txt
@@ -58,6 +58,7 @@ source_group("Text Files" FILES ${DevIL_TXT} )
 
 if(BUILD_SHARED_LIBS)
     add_library(IL SHARED ${DevIL_SRCS} ${DevIL_INC} ${DevIL_RSRC} ${DevIL_TXT})
+    set_target_properties(IL PROPERTIES SOVERSION 1)
 else(BUILD_SHARED_LIBS)
     add_library(IL ${DevIL_SRCS} ${DevIL_INC} ${DevIL_RSRC} ${DevIL_TXT})
 endif(BUILD_SHARED_LIBS)

--- a/DevIL/src-ILU/CMakeLists.txt
+++ b/DevIL/src-ILU/CMakeLists.txt
@@ -44,6 +44,7 @@ source_group("Resource Files" FILES ${ILU_RSRC} )
 
 # Remove SHARED to create a static library
 add_library(ILU SHARED ${ILU_SRCS} ${ILU_INC} ${ILU_RSRC})
+set_target_properties(ILU PROPERTIES SOVERSION 1)
 
 
 ## ILU requires IL

--- a/DevIL/src-ILUT/CMakeLists.txt
+++ b/DevIL/src-ILUT/CMakeLists.txt
@@ -44,6 +44,7 @@ source_group("Resource Files" FILES ${ILUT_RSRC} )
 
 # Remove SHARED to create a static library
 add_library(ILUT SHARED ${ILUT_SRCS} ${ILUT_INC} ${ILUT_RSRC})
+set_target_properties(ILUT PROPERTIES SOVERSION 1)
 
 ## add link sub library info
 target_link_libraries(ILUT


### PR DESCRIPTION
The previous version created `libIL.so.1`, `libILU.so.1` and `libILUT.so.1` shared object files.
Add the missing commands to the CMakeLists.txt files to do that for 1.8.0 as well.
