### PR TITLE
DDS files that specify DDS_PITCH load more reliably

### DIFF
--- a/DevIL/src-IL/src/il_dds.cpp
+++ b/DevIL/src-IL/src/il_dds.cpp
@@ -852,6 +852,8 @@ ILboolean ReadData(ILuint CompFormat, ILboolean IsDXT10)
 	else {
 		if (IsDXT10)
 			Bps = Head.LinearSize;  //@TODO: Head.RGBBitCount is always 0 from the texconv.exe tool?
+		else if ((Head.RGBBitCount == 0) && (Head.Flags1 & DDS_PITCH))
+			Bps = Head.LinearSize;  //@TODO: Microsoft recomends recomputing this instead.
 		else
 			Bps = Width * Head.RGBBitCount / 8;
 		CompSize = Bps * Height * Depth;


### PR DESCRIPTION
- Some files define Pitch instead of LinearSize
- The files sometimes also have RGBBitCount
- However, many do not, such as those in the NVTT test suite
-- https://github.com/castano/nvidia-texture-tools/blob/master/data/testsuite/lightmap/cottage.dds
- In other cases, DX10 formats more fully specify the data.
- In cases where we have no better path, use dwPitchOrLinearSize as pitch
-- Microsoft recommends recomputing pitch instead
-- https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dx-graphics-dds-pguide
-- However, had no convenient way to select correct method