### PR TITLE
Fix detection of big-endian systems

### DIFF
--- a/DevIL/src-IL/include/il_endian.h
+++ b/DevIL/src-IL/include/il_endian.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 #endif
 
-#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __BIG_ENDIAN__) \
+#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) \
   || (defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__))
 #undef __LITTLE_ENDIAN__
 #define Short(s) iSwapShort(s)


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html

> `__BYTE_ORDER__` is defined to one of the values `__ORDER_LITTLE_ENDIAN__`, `__ORDER_BIG_ENDIAN__`, or `__ORDER_PDP_ENDIAN__` ...