### PR TITLE
Fix parameter type in ivec_align_buffer prototype

### DIFF
--- a/DevIL/include/IL/devil_internal_exports.h
+++ b/DevIL/include/IL/devil_internal_exports.h
@@ -95,7 +95,7 @@ ILAPI void* ILAPIENTRY ialloc(const ILsizei Size);
 ILAPI void  ILAPIENTRY ifree(const void *Ptr);
 ILAPI void* ILAPIENTRY icalloc(const ILsizei Size, const ILsizei Num);
 #ifdef ALTIVEC_GCC
-ILAPI void* ILAPIENTRY ivec_align_buffer(void *buffer, const ILuint size);
+ILAPI void* ILAPIENTRY ivec_align_buffer(void *buffer, const ILsizei size);
 #endif
 
 // Internal library functions in IL


### PR DESCRIPTION
This changes the prototype of ivec_align_buffer to match its implementation in DevIL/src-IL/src/il_alloc.cpp thereby fixing a conflicting types error seen at least on PowerPC Macs. Thanks to @raphael-st for this fix.