### PR TITLE
Clear the entire header in iGetFitsHead

### DIFF
--- a/DevIL/src-IL/src/il_fits.cpp
+++ b/DevIL/src-IL/src/il_fits.cpp
@@ -102,7 +102,7 @@ ILboolean iGetFitsHead(FITSHEAD *Header)
 	ILenum	CardKey;
 
 //@TODO: Use something other than memset?
-	memset(Header, 0, sizeof(Header));  // Clear the header to all 0s first.
+	memset(Header, 0, sizeof(*Header));  // Clear the header to all 0s first.
 
 	do {
 		CardKey = GetCardImage(Header);


### PR DESCRIPTION
This sets the entire header to zeroes as was intended, rather than just the first 4 or 8 bytes.

(I am assuming that there is only one element and that we don't need to multiply this by a number of elements.)

Fixes compiler warning:

```
src-IL/src/il_fits.cpp:105:27: warning: 'memset' call operates on objects of type 'FITSHEAD' while the size is based on a different type 'FITSHEAD *' [-Wsizeof-pointer-memaccess]
        memset(Header, 0, sizeof(Header));  // Clear the header to all 0s first.
               ~~~~~~            ^~~~~~
src-IL/src/il_fits.cpp:105:27: note: did you mean to dereference the argument to 'sizeof' (and multiply it by the number of elements)?
        memset(Header, 0, sizeof(Header));  // Clear the header to all 0s first.
                                 ^~~~~~
```
