### PR TITLE
Compile against newer versions of Jasper

### DIFF
--- a/DevIL/src-IL/src/il_jp2.cpp
+++ b/DevIL/src-IL/src/il_jp2.cpp
@@ -314,13 +314,32 @@ ILboolean iLoadJp2Internal(jas_stream_t	*Stream, ILimage *Image)
 
 
 
+// Hack to compile against different versions of Jasper which expect
+// slightly different function types for their callbacks.  The defined()
+// checks are just looking for sybols that happen to have arrived around
+// the same time as the API change, so no reason they won't break in the
+// future :-(  Hopefully by the time it does nobody will care about pre-2.0.20
+// versions of jasper
+//
+// see: https://github.com/OSGeo/gdal/commit/9ef8e16e27c5fc4c491debe50bf2b7f3e94ed334
+//      https://github.com/DentonW/DevIL/issues/90
+#if defined(PRIjas_seqent)
+static int iJp2_file_read(jas_stream_obj_t *obj, char *buf, unsigned cnt)
+#else
 static int iJp2_file_read(jas_stream_obj_t *obj, char *buf, int cnt)
+#endif
 {
 	obj;
 	return iread(buf, 1, cnt);
 }
 
+#if defined(JAS_INCLUDE_JP2_CODEC)
+static int iJp2_file_write(jas_stream_obj_t *obj, const char *buf, unsigned cnt)
+#elif defined(PRIjas_seqent)
+static int iJp2_file_write(jas_stream_obj_t *obj, char *buf, unsigned cnt)
+#else
 static int iJp2_file_write(jas_stream_obj_t *obj, char *buf, int cnt)
+#endif
 {
 	obj;
 	return iwrite(buf, 1, cnt);


### PR DESCRIPTION
jasper changed the callback API (twice!)  This is the workaround that gdal used to deal with the problem in https://github.com/OSGeo/gdal/commit/9ef8e16e27c5fc4c491debe50bf2b7f3e94ed334

fixes #90