### PR TITLE
Replace set with append  to propagate previous CMAKE_MODULE_PATH list.

### DIFF
--- a/DevIL/CMakeLists.txt
+++ b/DevIL/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.6)
 
 project(ImageLib)
 # include our custom modules
-set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 add_subdirectory(src-IL)
 add_subdirectory(src-ILU)


### PR DESCRIPTION
Without this change I am not able to properly search my for my custom FindGLUT.cmake.
I does not break the build, but allows to provide user to specify own directories with FindXXX.cmake files.

