### PR TITLE
Fix RLE compression

### DIFF
--- a/DevIL/src-IL/src/il_rle.cpp
+++ b/DevIL/src-IL/src/il_rle.cpp
@@ -101,7 +101,6 @@ ILboolean ilRleCompressLine(ILubyte *p, ILuint n, ILubyte bpp,
 			n -= SameCount;
 			RLEBufSize += bpp + 1;
 			p += (SameCount - 1) * bpp;
-			*q++ = *p++;
 			switch(bpp) {
 				case 4:	*q++ = *p++;
 				case 3: *q++ = *p++;


### PR DESCRIPTION
An extra byte was being written in `ilRleCompressLine`. It was breaking RLE compressed images completely.