### PR TITLE
Fix TGA 2.0 extension writing according to specification

### DIFF
--- a/DevIL/src-IL/src/il_targa.cpp
+++ b/DevIL/src-IL/src/il_targa.cpp
@@ -789,9 +789,6 @@ ILboolean iSaveTargaInternal()
 	SaveLittleUShort((ILushort)Minute);
 	SaveLittleUShort((ILushort)Second);
 	
-	for (i = 0; i < 6; i++) {  // Time created
-		SaveLittleUShort(0);
-	}
 	for (i = 0; i < 41; i++) {	// Job name/ID
 		iputc(0);
 	}


### PR DESCRIPTION
Extension area was previously broken which is not noticeable unless you attempt to use info from it.