### PR TITLE
Fix register in cpp17 mode

### DIFF
--- a/DevIL/src-IL/src/il_manip.cpp
+++ b/DevIL/src-IL/src/il_manip.cpp
@@ -37,9 +37,9 @@ ILushort ILAPIENTRY ilFloatToHalf(ILuint i) {
 	// of float and half (127 versus 15).
 	//
 
-	register int s =  (i >> 16) & 0x00008000;
-	register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
-	register int m =   i        & 0x007fffff;
+	int s =  (i >> 16) & 0x00008000;
+	int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+	int m =   i        & 0x007fffff;
 
 	//
 	// Now reassemble s, e and m into a half:

--- a/DevIL/src-ILU/src/ilu_scaling.cpp
+++ b/DevIL/src-ILU/src/ilu_scaling.cpp
@@ -406,7 +406,7 @@ main(argc, argv)
 int argc;
 char *argv[];
 {
-	register int c;
+	int c;
 	int optind;
 	char *optarg;
 	int xsize = 0, ysize = 0;


### PR DESCRIPTION
Hi, all

Our vcpkg recently received an issue about `register ` no longer being used after the c++17 standard.
We provided a solution and I think we need to remove or replace it.

Related:
https://github.com/microsoft/vcpkg/issues/36653
https://github.com/microsoft/vcpkg/pull/36665